### PR TITLE
Add optional shape positional arg to IRQLine

### DIFF
--- a/lambdasoc/periph/event.py
+++ b/lambdasoc/periph/event.py
@@ -45,7 +45,7 @@ class EventSource:
 
 class IRQLine(Signal):
     """Interrupt request line."""
-    def __init__(self, *, name=None, src_loc_at=0):
+    def __init__(self, shape=None, *, name=None, src_loc_at=0):
         super().__init__(name=name, src_loc_at=1 + src_loc_at)
 
     __hash__ = object.__hash__


### PR DESCRIPTION
[Recently (May 23)](https://github.com/amaranth-lang/amaranth/commit/7d99981d571000fb427f051f1bbe9631c1a44145), amaranth changed the way Signals are initialized. There is now a [metaclass](https://github.com/amaranth-lang/amaranth/blame/cdf8fcc32ffc8bab7aaf01d9def893ced368e376/amaranth/hdl/ast.py#L971) that is hooked in, which is responsible for calling the actual concrete class's initializer. Currently it does so, like this: `signal = super().__call__(shape, **kwargs, src_loc_at=src_loc_at + 1)`.

So, all Signals and Signal subclasses now need to accept a shape positional arg. This causes a problem for IRQLine in lambdasoc, which defines its initializer as `def __init__(self, *, name=None, src_loc_at=0):`. So, if you try to use IRQLine with a newer amaranth checkout, you will get a somewhat confusing error like this (taken from a LUNA example SoC):

```
Traceback (most recent call last):
  File "examples/soc/hello/hello_world_soc.py", line 109, in <module>
    design = LunaCPUExample()
  File "examples/soc/hello/hello_world_soc.py", line 82, in __init__
    self.uart = uart = AsyncSerialPeripheral(core=uart_core)
  File "/home/asdf/luna/env_linux/src/lambdasoc/lambdasoc/periph/serial.py", line 91, in __init__
    self._bridge    = self.bridge(data_width=32, granularity=8, alignment=2)
  File "/home/asdf/luna/env_linux/src/lambdasoc/lambdasoc/periph/base.py", line 181, in bridge
    return PeripheralBridge(self, data_width=data_width, granularity=granularity,
  File "/home/asdf/luna/env_linux/src/lambdasoc/lambdasoc/periph/base.py", line 336, in __init__
    self._int_src = InterruptSource(events, name=periph.name)
  File "/home/asdf/luna/env_linux/src/lambdasoc/lambdasoc/periph/event.py", line 102, in __init__
    self.irq = IRQLine(name="{}_irq".format(self.name))
  File "/home/asdf/luna/env_linux/lib/python3.8/site-packages/amaranth/hdl/ast.py", line 973, in __call__
    signal = super().__call__(shape, **kwargs, src_loc_at=src_loc_at + 1)
TypeError: __init__() takes 1 positional argument but 2 positional arguments (and 2 keyword-only arguments) were given
```

Fortunately, all we need to do is accept that shape positional arg, and discard it or pass it on to the superclass initializer. We can even make it totally optional at the same time. As far as I know, IRQLine is the only class in lambdasoc that needs this change.

Thanks!